### PR TITLE
Remove --podir=po from install.sh for Gnome installation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -22,7 +22,6 @@ gnome-extensions pack ./ \
     --extra-source=preferences/ \
     --extra-source=ui/ \
     --extra-source=script/ \
-    --podir=po \
     --force \
 
 if [ $? -ne 0 ]; then 


### PR DESCRIPTION
Remove the --podir=po option from the install script.